### PR TITLE
Fix with-editor fetch url

### DIFF
--- a/inits/05-vcs.el
+++ b/inits/05-vcs.el
@@ -17,7 +17,7 @@
     (setq flymake-fringe-overlays nil)))
 (el-get-bundle with-editor
   :type http
-  :url "https://raw.githubusercontent.com/magit/magit/master/lisp/with-editor.el")
+  :url "https://raw.githubusercontent.com/magit/with-editor/master/with-editor.el")
 (el-get-bundle git-commit
   :type http
   :url "https://raw.githubusercontent.com/magit/magit/master/lisp/git-commit.el")


### PR DESCRIPTION
https://raw.githubusercontent.com/magit/magit/master/lisp/with-editor.el is currently unavailable.
Changed to new URL.
